### PR TITLE
Standardize the HTTP status line to make the example run on all browsers

### DIFF
--- a/cat_server/helloworld_web/cat_server.ml
+++ b/cat_server/helloworld_web/cat_server.ml
@@ -5,7 +5,7 @@ module Main (C:CONSOLE) (S: STACKV4) = struct
   let on_error_close = fun console flow ->
     C.log console "An error occured"; S.TCPV4.close flow
 
-  let http_response = "HTTP 1.0 200 OK\r\nContent-Type:
+  let http_response = "HTTP/1.0 200 OK\r\nContent-Type:
     text/html\r\n\r\n<html><body><h1>Hello world!</h1></body></html>"
 
   let send_response = fun console flow ->


### PR DESCRIPTION
e.g. Firefox is now working correctly instead of showing all the HTTP headers as text
